### PR TITLE
fix: preserve language selection after flashcard generation

### DIFF
--- a/src/components/TryItOutDemo.tsx
+++ b/src/components/TryItOutDemo.tsx
@@ -64,7 +64,7 @@ export function TryItOutDemo() {
 
       if (result.success) {
         setFlashcards(result.data.flashcards);
-        form.reset(); // Clear the form on success
+        form.setValue("prompt", ""); // Only clear the prompt, preserve language selection
 
         // Smooth scroll to flashcards after a brief delay
         setTimeout(() => {


### PR DESCRIPTION
This PR fixes issue #41 where the language selection was resetting to Spanish after flashcard generation on the landing page demo.

## Changes
- Replaced `form.reset()` with `form.setValue("prompt", "")` in `TryItOutDemo.tsx`
- This preserves the user's language selection while only clearing the prompt input

## Testing
The fix ensures that when a user:
1. Selects a language other than Spanish
2. Generates flashcards with a prompt
3. The language selection remains unchanged after generation

Fixes #41

Generated with [Claude Code](https://claude.ai/code)