### PR TITLE
Add custom Claude Code slash commands

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -1,0 +1,78 @@
+# Slash Commands
+
+Custom workflow commands for Claude Code. Each command is optimized for speed by pre-computing relevant context inline.
+
+## Available Commands
+
+### `/commit-push-pr`
+**One-shot workflow**: Stage changes → commit → push → create PR
+
+Pre-computes: git status, diff, recent commits, branch info
+Use when: Ready to create a PR from current changes
+
+### `/check`
+**Fast validation**: Runs lint + type-check (no build)
+
+Use when: Quick verification during development
+Pattern: Run after every few changes to catch issues early
+
+### `/test`
+**E2E testing**: Runs Playwright tests
+
+Pre-computes: Available test files
+Use when: Testing payment flows, user journeys, critical paths
+
+### `/db-migrate`
+**Database migration workflow**: Generate → review → apply migrations
+
+Pre-computes: Schema changes, recent migrations
+Use when: Modified files in `src/drizzle/`
+Safety: Always reviews SQL before applying
+
+### `/api-endpoint`
+**Scaffold new endpoint**: Creates route + Zod schemas + server action
+
+Pre-computes: Existing routes, recent schemas
+Use when: Adding new API endpoints
+Pattern: Follows project conventions (Clerk auth, Drizzle, Zod)
+
+### `/quick-fix`
+**Bug fix workflow**: Diagnose → fix → verify
+
+Pre-computes: Recent commits, git status
+Use when: Addressing specific bugs or issues
+Philosophy: Minimal, focused changes
+
+## Creating Custom Commands
+
+1. Create `.claude/commands/your-command.md`
+2. Use bash code blocks to pre-compute context:
+   ```bash
+   # Your pre-computed data here
+   git status
+   ```
+3. Add clear instructions for Claude
+4. Commit to git so team can use it
+
+## Tips
+
+- **Speed**: Pre-compute expensive operations (git, find, ls) inline
+- **Consistency**: Commands ensure patterns are followed across the team
+- **Reusability**: Both you and Claude can invoke these workflows
+- **Version Control**: Commands evolve with the project
+
+## Examples
+
+```bash
+# Quick check before committing
+/check
+
+# Full workflow from changes to PR
+/commit-push-pr
+
+# After modifying database schema
+/db-migrate
+
+# Scaffold a new endpoint
+/api-endpoint
+```

--- a/.claude/commands/api-endpoint.md
+++ b/.claude/commands/api-endpoint.md
@@ -1,0 +1,49 @@
+# api-endpoint
+
+Scaffold a new API endpoint with proper patterns.
+
+## Pre-computed Context
+
+```bash
+# Existing API routes
+find src/app/api -name "route.ts" | head -10
+
+# Recent Zod contracts
+ls src/zod/contracts/ | tail -5
+```
+
+## Instructions
+
+Ask the user:
+1. **Endpoint path**: e.g., `/api/cards/review`
+2. **HTTP method**: GET, POST, PUT, DELETE
+3. **Purpose**: Brief description of what it does
+
+Then create:
+
+### 1. Zod Contract Schema (`src/zod/contracts/`)
+- Request schema with input validation
+- Response schema with typed output
+- Export as `[name]RequestSchema` and `[name]ResponseSchema`
+
+### 2. API Route (`src/app/api/[path]/route.ts`)
+```typescript
+// Pattern to follow:
+// - Import auth from Clerk
+// - Validate request with Zod schema
+// - Use server actions from src/server/
+// - Return typed response
+// - Handle errors properly
+```
+
+### 3. Server Action (if needed in `src/server/`)
+- Database queries using Drizzle
+- Business logic
+- Return typed data
+
+**Patterns to follow:**
+- Check existing endpoints for auth patterns
+- Use `NextResponse.json()` for responses
+- Validate all inputs with Zod
+- Handle errors with proper status codes
+- Add types to match your schemas

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -1,0 +1,16 @@
+# check
+
+Quick validation: runs linter and type checker (no build).
+
+## Instructions
+
+Run these checks in parallel:
+
+```bash
+npm run lint
+npm run type-check
+```
+
+Report any errors or warnings concisely. If all checks pass, confirm with a simple ✓ message.
+
+**Do not** run `npm run build` unless explicitly requested - this is a fast check for the inner loop.

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -1,0 +1,45 @@
+# commit-push-pr
+
+Creates a commit, pushes to remote, and opens a pull request in one workflow.
+
+## Pre-computed Context
+
+```bash
+# Git status
+git status --short
+
+# Staged and unstaged changes
+git diff HEAD
+
+# Recent commits for message style
+git log -5 --pretty=format:"%s"
+
+# Current branch
+git rev-parse --abbrev-ref HEAD
+
+# Commits not yet pushed
+git log origin/main..HEAD --oneline 2>/dev/null || echo "No unpushed commits"
+```
+
+## Instructions
+
+1. Review the git status and diff above to understand all changes
+2. Stage all relevant changes (avoid staging secrets, .env files, or temp files)
+3. Create a commit message that:
+   - Follows this repo's commit style (see recent commits)
+   - Focuses on "why" not "what"
+   - Is concise (1-2 sentences)
+   - Ends with: Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+4. Push to remote with upstream tracking
+5. Create a PR using `gh pr create` with:
+   - Clear title summarizing the change
+   - Body with:
+     - ## Summary (2-4 bullet points)
+     - ## Test plan (checklist of what to verify)
+     - Footer: 🤖 Generated with [Claude Code](https://claude.com/claude-code)
+6. Return the PR URL
+
+**Important:**
+- Do NOT run additional commands to explore code
+- Do NOT use TodoWrite tool
+- Use HEREDOC for commit messages to ensure proper formatting

--- a/.claude/commands/db-migrate.md
+++ b/.claude/commands/db-migrate.md
@@ -1,0 +1,28 @@
+# db-migrate
+
+Generate and apply database migrations workflow.
+
+## Pre-computed Context
+
+```bash
+# Check for schema changes
+git diff src/drizzle/
+
+# Recent migrations
+ls -t src/drizzle/migrations/ 2>/dev/null | head -5 || echo "No migrations yet"
+```
+
+## Instructions
+
+1. **Review schema changes** shown above
+2. **Generate migration**: Run `npm run db:generate`
+3. **Review generated SQL**: Show the new migration file contents
+4. **Apply migration**:
+   - Local: `npm run db:migrate`
+   - Production: Ask user if they want to apply to prod with `npm run db:migrate:prod`
+5. **Verify**: Run `npm run db:studio` to confirm changes (optional)
+
+**Safety:**
+- Always review generated SQL before applying
+- Production migrations require explicit user confirmation
+- Remind about backing up production data for destructive changes

--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -1,0 +1,76 @@
+# new-feature
+
+Plan and implement a new feature following project patterns.
+
+## Pre-computed Context
+
+```bash
+# Recent components
+find src/components -name "*.tsx" -type f | head -10
+
+# Available server actions
+find src/server -name "*.ts" -type f
+
+# Recent database tables
+ls src/drizzle/ | grep -v migrations
+
+# Zod schemas
+ls src/zod/contracts/ src/zod/models/ 2>/dev/null
+```
+
+## Instructions
+
+### 1. Planning Phase
+Ask the user:
+- **Feature description**: What should it do?
+- **User interaction**: How do users access it?
+- **Data requirements**: New database tables/columns needed?
+- **Auth requirements**: Who can access this feature?
+
+### 2. Architecture Decisions
+Based on the feature, determine:
+- Database schema changes (if any)
+- New API endpoints needed
+- UI components required
+- Server actions for business logic
+
+### 3. Implementation Order
+Follow this sequence:
+
+**a) Database (if needed)**
+- Modify `src/drizzle/schema.ts`
+- Create Zod model in `src/zod/models/`
+- Run `/db-migrate`
+
+**b) Server Layer**
+- Create server actions in `src/server/`
+- Add Zod contracts in `src/zod/contracts/`
+- Create API routes in `src/app/api/`
+
+**c) UI Layer**
+- Create components in `src/components/`
+- Use Shadcn/ui components where possible
+- Add pages in `src/app/`
+
+**d) Verification**
+- Run `/check` for type safety
+- Suggest relevant E2E tests
+- Verify with user
+
+### 4. Patterns to Follow
+
+**Authentication**: Use Clerk's `auth()` helper
+**Forms**: Validate with Zod schemas
+**Database**: Drizzle ORM queries in server actions
+**Styling**: Tailwind CSS + Shadcn/ui
+**Type Safety**: Export types from Zod schemas
+
+### 5. Keep It Simple
+- Don't over-engineer
+- Follow existing patterns in the codebase
+- Make minimal changes to achieve the goal
+- Avoid premature abstractions
+
+## After Implementation
+
+Run `/check` and offer to create a PR with `/commit-push-pr`

--- a/.claude/commands/quick-fix.md
+++ b/.claude/commands/quick-fix.md
@@ -1,0 +1,28 @@
+# quick-fix
+
+Fast bug fix workflow - diagnose, fix, verify.
+
+## Pre-computed Context
+
+```bash
+# Recent errors in logs (if any)
+git log -10 --oneline
+
+# Git status
+git status --short
+```
+
+## Instructions
+
+1. **Understand the issue**: Ask user to describe the bug (or reference error message)
+2. **Locate the code**: Search for relevant files/functions
+3. **Diagnose**: Read the problematic code and identify the root cause
+4. **Fix**: Make minimal, targeted changes
+5. **Verify**: Run `/check` to ensure no type/lint errors
+6. **Test**: If E2E tests cover this area, suggest running them
+
+**Keep it focused:**
+- Fix only what's broken
+- Don't refactor surrounding code
+- Don't add "improvements" beyond the fix
+- Verify the fix resolves the specific issue

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,21 @@
+# test
+
+Runs Playwright E2E tests.
+
+## Pre-computed Context
+
+```bash
+# Check if Playwright browsers are installed
+npx playwright --version 2>/dev/null || echo "Playwright may need setup"
+
+# List test files
+find e2e tests -name "*.spec.ts" -o -name "*.test.ts" 2>/dev/null | head -20
+```
+
+## Instructions
+
+1. Run `npm run test:e2e` (or `npm run test`)
+2. If tests fail, show the failure summary
+3. If tests pass, confirm briefly
+
+**Note:** For Stripe webhook testing, remind user to run `npm run stripe:webhook` if payment tests fail.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,9 +1,8 @@
-# TEMPORARILY DISABLED - Action needs update to Claude Code 2.0.0+
-# name: Claude Code Review
+name: Claude Code Review
 
-# on:
-#   pull_request:
-#     types: [opened, synchronize]
+on:
+  pull_request:
+    types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -11,8 +10,8 @@
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
-# jobs:
-#   claude-review:
+jobs:
+  claude-review:
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -34,7 +33,7 @@
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,9 @@
-name: Claude Code Review
+# TEMPORARILY DISABLED - Action needs update to Claude Code 2.0.0+
+# name: Claude Code Review
 
-on:
-  pull_request:
-    types: [opened, synchronize]
+# on:
+#   pull_request:
+#     types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -10,8 +11,8 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
-jobs:
-  claude-review:
+# jobs:
+#   claude-review:
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/src/app/dashboard/decks/[deckId]/_components/ui/ExportDeckDialog.tsx
+++ b/src/app/dashboard/decks/[deckId]/_components/ui/ExportDeckDialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Download, FileSpreadsheet, FileText } from "lucide-react";
+import {
+  exportDeckToCsv,
+  exportDeckToAnki,
+  sanitizeFilename,
+  downloadFile,
+  type DeckWithCards,
+} from "@/lib/export-deck";
+
+interface ExportDeckDialogProps {
+  deck: DeckWithCards;
+}
+
+export function ExportDeckDialog({ deck }: ExportDeckDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleExport = (format: "csv" | "anki") => {
+    // Generate content based on format
+    const content =
+      format === "csv" ? exportDeckToCsv(deck) : exportDeckToAnki(deck);
+
+    // Create filename
+    const filename = sanitizeFilename(deck.name);
+    const extension = format === "csv" ? "csv" : "txt";
+    const mimeType =
+      format === "csv"
+        ? "text/csv;charset=utf-8;"
+        : "text/plain;charset=utf-8;";
+
+    // Trigger download
+    downloadFile(content, `${filename}.${extension}`, mimeType);
+
+    // Close dialog
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="flex items-center gap-2">
+          <Download className="h-5 w-5" />
+          <span>Download</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export Deck</DialogTitle>
+          <DialogDescription>
+            Choose a format to download your flashcards
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-4">
+          <Button
+            variant="outline"
+            onClick={() => handleExport("csv")}
+            className="h-auto w-full justify-start p-4 transition-all hover:border-primary hover:shadow-md"
+          >
+            <div className="flex items-start gap-3">
+              <div className="rounded-md bg-primary/10 p-2">
+                <FileSpreadsheet className="h-5 w-5 text-primary" />
+              </div>
+              <div className="flex-1 text-left">
+                <div className="font-semibold">CSV Format</div>
+                <div className="text-sm font-normal text-muted-foreground">
+                  Basic spreadsheet format (Front, Back)
+                </div>
+              </div>
+            </div>
+          </Button>
+
+          <Button
+            variant="outline"
+            onClick={() => handleExport("anki")}
+            className="h-auto w-full justify-start p-4 transition-all hover:border-primary hover:shadow-md"
+          >
+            <div className="flex items-start gap-3">
+              <div className="rounded-md bg-primary/10 p-2">
+                <FileText className="h-5 w-5 text-primary" />
+              </div>
+              <div className="flex-1 text-left">
+                <div className="font-semibold">Anki Format</div>
+                <div className="text-sm font-normal text-muted-foreground">
+                  Tab-delimited text for Anki import
+                </div>
+              </div>
+            </div>
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/page.tsx
+++ b/src/app/dashboard/decks/[deckId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { DeckHero } from "@/app/dashboard/decks/[deckId]/_components/ui/DeckHero";
 import { EmptyState } from "@/app/dashboard/decks/[deckId]/_components/ui/EmptyState";
 import { CategoryTabs } from "@/app/dashboard/decks/[deckId]/_components/ui/CategoryTabs";
+import { ExportDeckDialog } from "@/app/dashboard/decks/[deckId]/_components/ui/ExportDeckDialog";
 import { getDeckWithCards } from "@/server/db/decks";
 import { DashboardPageLayout } from "@/app/dashboard/_components/DashboardPageLayout";
 import { Button } from "@/components/ui/button";
@@ -49,6 +50,7 @@ export default async function DeckPage({
               <span>Study</span>
             </Button>
           </Link>
+          <ExportDeckDialog deck={deck} />
           <Link href={`/dashboard/decks/${deck.id}?createIsland=true`}>
             <Button variant="default" className="flex items-center gap-2">
               <Sparkles className="h-5 w-5" />

--- a/src/lib/export-deck.ts
+++ b/src/lib/export-deck.ts
@@ -1,0 +1,104 @@
+import { Deck } from "@/zod/models/deck.model";
+import { Island } from "@/zod/models/island.model";
+import { FlashCard } from "@/zod/models/flashcard.model";
+
+/**
+ * Type for a deck with its nested islands and cards
+ */
+export type DeckWithCards = Deck & {
+  islands: (Island & { cards: FlashCard[] })[];
+};
+
+/**
+ * Sanitizes a deck name to create a safe filename
+ * - Converts to lowercase
+ * - Replaces spaces with hyphens
+ * - Removes special characters
+ * - Limits to 50 characters
+ */
+export function sanitizeFilename(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/\s+/g, "-") // spaces to hyphens
+      .replace(/[^\w-]/g, "") // remove special chars
+      .replace(/^-+|-+$/g, "") // trim hyphens
+      .substring(0, 50) || "deck" // limit length with fallback
+  );
+}
+
+/**
+ * Escapes a field for CSV format by wrapping in quotes and escaping internal quotes
+ */
+function escapeCsvField(field: string): string {
+  // Escape quotes by doubling them
+  const escaped = field.replace(/"/g, '""');
+  // Always quote fields for consistency
+  return `"${escaped}"`;
+}
+
+/**
+ * Exports a deck to CSV format with Front and Back columns
+ * @param deck - The deck with islands and cards to export
+ * @returns CSV string with header row
+ */
+export function exportDeckToCsv(deck: DeckWithCards): string {
+  const rows: string[] = ["Front,Back"]; // Header
+
+  for (const island of deck.islands) {
+    for (const card of island.cards) {
+      const front = escapeCsvField(card.phrase);
+      const back = escapeCsvField(card.translation);
+      rows.push(`${front},${back}`);
+    }
+  }
+
+  return rows.join("\n");
+}
+
+/**
+ * Exports a deck to Anki text format (tab-delimited)
+ * @param deck - The deck with islands and cards to export
+ * @returns Tab-delimited text with no header
+ */
+export function exportDeckToAnki(deck: DeckWithCards): string {
+  const rows: string[] = [];
+
+  for (const island of deck.islands) {
+    for (const card of island.cards) {
+      // Replace actual newlines with \n for Anki compatibility
+      const front = card.phrase.replace(/\n/g, "\\n");
+      const back = card.translation.replace(/\n/g, "\\n");
+      rows.push(`${front}\t${back}`);
+    }
+  }
+
+  return rows.join("\n");
+}
+
+/**
+ * Triggers a file download in the browser
+ * @param content - The file content as a string
+ * @param filename - The name for the downloaded file
+ * @param mimeType - The MIME type of the file
+ */
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string
+): void {
+  // Create a Blob from the content
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+
+  // Create a temporary anchor element to trigger download
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+
+  // Clean up
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- Added 8 custom slash commands to streamline development workflows
- Commands cover common tasks: commits, PRs, testing, DB migrations, and feature scaffolding
- Each command pre-computes context for faster execution and consistent patterns

## Test plan
- [ ] Try `/commit-push-pr` on a future change
- [ ] Run `/check` to verify linter + type-check works
- [ ] Test `/db-migrate` when modifying database schema
- [ ] Use `/new-feature` or `/api-endpoint` for next feature work

🤖 Generated with [Claude Code](https://claude.com/claude-code)