### PR TITLE
Add study mode selection with multiple learning modes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,23 +39,23 @@ jobs:
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          
+
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true
           
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
@@ -63,7 +63,7 @@ jobs:
           #   - For tests: Coverage, edge cases, and test quality
           
           # Optional: Different prompts for different authors
-          # direct_prompt: |
+          # prompt: |
           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}

--- a/src/app/dashboard/decks/[deckId]/study/_components/ModeCard.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/_components/ModeCard.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { BookOpen, MessageCircle, Headphones } from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const iconMap = {
+  BookOpen,
+  MessageCircle,
+  Headphones,
+} as const;
+
+interface ModeCardProps {
+  href: string;
+  iconName: keyof typeof iconMap;
+  title: string;
+  description: string;
+  colorClass: string;
+  index: number;
+}
+
+export function ModeCard({
+  href,
+  iconName,
+  title,
+  description,
+  colorClass,
+  index,
+}: ModeCardProps) {
+  const Icon = iconMap[iconName];
+  return (
+    <Link href={href}>
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: index * 0.1, duration: 0.3 }}
+        whileHover={{ scale: 1.02, y: -4 }}
+        className="h-full"
+      >
+        <Card className="relative h-full cursor-pointer transition-all duration-200 hover:shadow-lg border-2 hover:border-primary/20">
+          <CardHeader className="space-y-4 p-8">
+            <div
+              className={cn(
+                "w-16 h-16 rounded-xl flex items-center justify-center",
+                "bg-gradient-to-br",
+                colorClass
+              )}
+            >
+              <Icon className="h-8 w-8 text-white" />
+            </div>
+
+            <div className="space-y-2">
+              <CardTitle className="text-2xl">{title}</CardTitle>
+              <CardDescription className="text-base">
+                {description}
+              </CardDescription>
+            </div>
+          </CardHeader>
+        </Card>
+      </motion.div>
+    </Link>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/_components/StudyModeSelector.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/_components/StudyModeSelector.tsx
@@ -1,0 +1,53 @@
+import { ModeCard } from "./ModeCard";
+
+interface StudyModeSelectorProps {
+  deckId: string;
+  cardCount: number;
+}
+
+export function StudyModeSelector({
+  deckId,
+  cardCount,
+}: StudyModeSelectorProps) {
+  const modes = [
+    {
+      href: `/dashboard/decks/${deckId}/study/standard`,
+      iconName: "BookOpen" as const,
+      title: "Standard Study",
+      description: "Traditional flashcard practice with spaced repetition",
+      colorClass: "from-blue-500 to-blue-600",
+    },
+    {
+      href: `/dashboard/decks/${deckId}/study/conversation`,
+      iconName: "MessageCircle" as const,
+      title: "Conversational Study",
+      description: "Practice with AI-powered conversations in context",
+      colorClass: "from-purple-500 to-purple-600",
+    },
+    {
+      href: `/dashboard/decks/${deckId}/study/listening`,
+      iconName: "Headphones" as const,
+      title: "Listening Practice",
+      description: "Improve comprehension with audio-focused exercises",
+      colorClass: "from-green-500 to-green-600",
+    },
+  ];
+
+  return (
+    <div className="space-y-8">
+      {/* Card count info */}
+      <div className="text-center">
+        <p className="text-muted-foreground">
+          {cardCount} {cardCount === 1 ? "card" : "cards"} ready to practice
+        </p>
+      </div>
+
+      {/* Mode Cards Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-6xl mx-auto">
+        {modes.map((mode, index) => (
+          <ModeCard key={mode.title} {...mode} index={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/conversation/_components/ConversationalStudyMode.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/conversation/_components/ConversationalStudyMode.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { MessageCircle, ArrowLeft, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+interface ConversationalStudyModeProps {
+  deckId: string;
+  deckName: string;
+}
+
+export function ConversationalStudyMode({
+  deckId,
+  deckName,
+}: ConversationalStudyModeProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[80vh] p-6">
+      <Card className="max-w-2xl w-full">
+        <CardHeader className="space-y-6 text-center">
+          <div className="flex justify-center">
+            <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-purple-500 to-purple-600 flex items-center justify-center">
+              <MessageCircle className="h-10 w-10 text-white" />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-center gap-2 mb-2">
+              <CardTitle className="text-3xl">Conversational Study</CardTitle>
+              <Badge variant="secondary">Coming Soon</Badge>
+            </div>
+            <CardDescription className="text-lg">
+              for <span className="font-semibold">{deckName}</span>
+            </CardDescription>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          <p className="text-center text-muted-foreground">
+            Practice your language skills through AI-powered conversations based
+            on the flashcards in your deck. Have natural dialogues that adapt to
+            your skill level.
+          </p>
+
+          <div className="space-y-3">
+            <h3 className="font-semibold flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-purple-500" />
+              Planned Features
+            </h3>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <span className="text-purple-500 font-bold mt-0.5">•</span>
+                <span>
+                  Natural conversations with AI tutor based on your deck content
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-purple-500 font-bold mt-0.5">•</span>
+                <span>
+                  Context-aware responses that adapt to your skill level
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-purple-500 font-bold mt-0.5">•</span>
+                <span>Real-time pronunciation feedback and corrections</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-purple-500 font-bold mt-0.5">•</span>
+                <span>Conversation history and progress tracking</span>
+              </li>
+            </ul>
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <Button
+              variant="outline"
+              onClick={() =>
+                router.push(`/dashboard/decks/${deckId}/study`)
+              }
+              className="flex-1"
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Modes
+            </Button>
+
+            <Button
+              onClick={() =>
+                router.push(`/dashboard/decks/${deckId}/study/standard`)
+              }
+              className="flex-1"
+            >
+              Try Standard Study
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/conversation/page.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/conversation/page.tsx
@@ -1,0 +1,24 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
+import { getDeckWithCards } from "@/server/db/decks";
+import { ConversationalStudyMode } from "./_components/ConversationalStudyMode";
+
+export default async function ConversationalStudyPage({
+  params,
+}: {
+  params: Promise<{ deckId: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Not authenticated");
+  }
+
+  const { deckId } = await params;
+  const deck = await getDeckWithCards(deckId);
+
+  if (!deck) {
+    notFound();
+  }
+
+  return <ConversationalStudyMode deckId={deckId} deckName={deck.name} />;
+}

--- a/src/app/dashboard/decks/[deckId]/study/listening/_components/ListeningStudyMode.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/listening/_components/ListeningStudyMode.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Headphones, ArrowLeft, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+interface ListeningStudyModeProps {
+  deckId: string;
+  deckName: string;
+}
+
+export function ListeningStudyMode({
+  deckId,
+  deckName,
+}: ListeningStudyModeProps) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[80vh] p-6">
+      <Card className="max-w-2xl w-full">
+        <CardHeader className="space-y-6 text-center">
+          <div className="flex justify-center">
+            <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-green-500 to-green-600 flex items-center justify-center">
+              <Headphones className="h-10 w-10 text-white" />
+            </div>
+          </div>
+
+          <div>
+            <div className="flex items-center justify-center gap-2 mb-2">
+              <CardTitle className="text-3xl">Listening Practice</CardTitle>
+              <Badge variant="secondary">Coming Soon</Badge>
+            </div>
+            <CardDescription className="text-lg">
+              for <span className="font-semibold">{deckName}</span>
+            </CardDescription>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          <p className="text-center text-muted-foreground">
+            Improve your comprehension with audio-focused exercises that
+            emphasize listening and pronunciation skills. Perfect for
+            strengthening your ear for the language.
+          </p>
+
+          <div className="space-y-3">
+            <h3 className="font-semibold flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-green-500" />
+              Planned Features
+            </h3>
+            <ul className="space-y-2 text-sm text-muted-foreground">
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 font-bold mt-0.5">•</span>
+                <span>
+                  Audio-first interface with text-to-speech for all phrases
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 font-bold mt-0.5">•</span>
+                <span>
+                  Adjustable playback speed to match your comprehension level
+                </span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 font-bold mt-0.5">•</span>
+                <span>Repeat and loop functionality for difficult phrases</span>
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="text-green-500 font-bold mt-0.5">•</span>
+                <span>Dictation mode to practice spelling from audio</span>
+              </li>
+            </ul>
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <Button
+              variant="outline"
+              onClick={() =>
+                router.push(`/dashboard/decks/${deckId}/study`)
+              }
+              className="flex-1"
+            >
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Modes
+            </Button>
+
+            <Button
+              onClick={() =>
+                router.push(`/dashboard/decks/${deckId}/study/standard`)
+              }
+              className="flex-1"
+            >
+              Try Standard Study
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/listening/page.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/listening/page.tsx
@@ -1,0 +1,24 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
+import { getDeckWithCards } from "@/server/db/decks";
+import { ListeningStudyMode } from "./_components/ListeningStudyMode";
+
+export default async function ListeningStudyPage({
+  params,
+}: {
+  params: Promise<{ deckId: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Not authenticated");
+  }
+
+  const { deckId } = await params;
+  const deck = await getDeckWithCards(deckId);
+
+  if (!deck) {
+    notFound();
+  }
+
+  return <ListeningStudyMode deckId={deckId} deckName={deck.name} />;
+}

--- a/src/app/dashboard/decks/[deckId]/study/loading.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/loading.tsx
@@ -1,0 +1,36 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function StudyLoading() {
+  return (
+    <div className="min-h-[80vh] flex flex-col items-center justify-center p-4">
+      <div className="w-full max-w-6xl space-y-8">
+        {/* Header skeleton */}
+        <div className="space-y-2 text-center">
+          <Skeleton className="h-10 w-64 mx-auto" />
+          <Skeleton className="h-6 w-48 mx-auto" />
+          <Skeleton className="h-4 w-32 mx-auto" />
+        </div>
+
+        {/* Mode cards skeleton */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {[1, 2, 3].map((i) => (
+            <div
+              key={i}
+              className="space-y-4 p-8 border-2 rounded-xl"
+            >
+              <Skeleton className="h-16 w-16 rounded-xl" />
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6" />
+            </div>
+          ))}
+        </div>
+
+        {/* Keyboard hint skeleton */}
+        <div className="hidden md:flex justify-center">
+          <Skeleton className="h-6 w-64" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/page.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/page.tsx
@@ -1,9 +1,10 @@
 import { auth } from "@clerk/nextjs/server";
 import { notFound } from "next/navigation";
 import { getDeckWithCards } from "@/server/db/decks";
-import { StudyMode } from "./_components/StudyMode";
+import { StudyModeSelector } from "./_components/StudyModeSelector";
+import { DashboardPageLayout } from "@/app/dashboard/_components/DashboardPageLayout";
 
-export default async function StudyPage({
+export default async function StudyModeSelectorPage({
   params,
 }: {
   params: Promise<{ deckId: string }>;
@@ -25,27 +26,29 @@ export default async function StudyPage({
 
   if (allCards.length === 0) {
     return (
-      <div className="w-full p-6 flex flex-col items-center justify-center h-[80vh] space-y-4">
-        <h2 className="text-2xl font-bold">No cards to study</h2>
-        <p className="text-lg text-muted-foreground">
-          This deck doesn&apos;t have any flashcards yet.
-        </p>
-        <a
-          href={`/dashboard/decks/${deckId}`}
-          className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
-        >
-          Back to Deck
-        </a>
-      </div>
+      <DashboardPageLayout
+        pageTitle="Study Mode"
+        backButtonHref={`/dashboard/decks/${deckId}`}
+      >
+        <div className="flex flex-col items-center justify-center h-[60vh] space-y-4">
+          <h2 className="text-2xl font-bold">No cards to study</h2>
+          <p className="text-lg text-muted-foreground">
+            This deck doesn&apos;t have any flashcards yet.
+          </p>
+        </div>
+      </DashboardPageLayout>
     );
   }
 
   return (
-    <StudyMode
-      cards={allCards}
-      deckId={deckId}
-      deckName={deck.name}
-      deckLanguage={deck.language}
-    />
+    <DashboardPageLayout
+      pageTitle={`Study: ${deck.name}`}
+      backButtonHref={`/dashboard/decks/${deckId}`}
+    >
+      <StudyModeSelector
+        deckId={deckId}
+        cardCount={allCards.length}
+      />
+    </DashboardPageLayout>
   );
 }

--- a/src/app/dashboard/decks/[deckId]/study/page.tsx.backup
+++ b/src/app/dashboard/decks/[deckId]/study/page.tsx.backup
@@ -1,0 +1,51 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
+import { getDeckWithCards } from "@/server/db/decks";
+import { StudyMode } from "./_components/StudyMode";
+
+export default async function StudyPage({
+  params,
+}: {
+  params: Promise<{ deckId: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Not authenticated");
+  }
+
+  const { deckId } = await params;
+
+  const deck = await getDeckWithCards(deckId);
+  if (!deck) {
+    notFound();
+  }
+
+  // Flatten all cards from all islands
+  const allCards = deck.islands.flatMap((island) => island.cards);
+
+  if (allCards.length === 0) {
+    return (
+      <div className="w-full p-6 flex flex-col items-center justify-center h-[80vh] space-y-4">
+        <h2 className="text-2xl font-bold">No cards to study</h2>
+        <p className="text-lg text-muted-foreground">
+          This deck doesn&apos;t have any flashcards yet.
+        </p>
+        <a
+          href={`/dashboard/decks/${deckId}`}
+          className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
+        >
+          Back to Deck
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <StudyMode
+      cards={allCards}
+      deckId={deckId}
+      deckName={deck.name}
+      deckLanguage={deck.language}
+    />
+  );
+}

--- a/src/app/dashboard/decks/[deckId]/study/standard/_components/StandardStudyMode.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/standard/_components/StandardStudyMode.tsx
@@ -14,24 +14,24 @@ import { CardDifficulty } from "@/data/cardDifficulties";
 import { SupportedLanguageCode } from "@/data/supportedLanguages";
 import { ArrowLeft, ArrowRight, Volume2 } from "lucide-react";
 import { FlashCard } from "@/zod/models/flashcard.model";
-import { updateCardAction } from "../../actions";
+import { updateCardAction } from "../../../actions";
 import { cn } from "@/lib/utils";
 import { speak } from "@/lib/textToSpeech";
 import { motion, AnimatePresence } from "framer-motion";
 
-interface StudyModeProps {
+interface StandardStudyModeProps {
   cards: FlashCard[];
   deckId: string;
   deckName: string;
   deckLanguage: SupportedLanguageCode;
 }
 
-export function StudyMode({
+export function StandardStudyMode({
   cards,
   deckId,
   deckName,
   deckLanguage,
-}: StudyModeProps) {
+}: StandardStudyModeProps) {
   const router = useRouter();
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);

--- a/src/app/dashboard/decks/[deckId]/study/standard/page.tsx
+++ b/src/app/dashboard/decks/[deckId]/study/standard/page.tsx
@@ -1,0 +1,53 @@
+import { auth } from "@clerk/nextjs/server";
+import { notFound } from "next/navigation";
+import { getDeckWithCards } from "@/server/db/decks";
+import { StandardStudyMode } from "./_components/StandardStudyMode";
+import Link from "next/link";
+
+export default async function StandardStudyPage({
+  params,
+}: {
+  params: Promise<{ deckId: string }>;
+}) {
+  const { userId } = await auth();
+  if (!userId) {
+    throw new Error("Not authenticated");
+  }
+
+  const { deckId } = await params;
+
+  const deck = await getDeckWithCards(deckId);
+  if (!deck) {
+    notFound();
+  }
+
+  // Flatten all cards from all islands
+  const allCards = deck.islands.flatMap((island) => island.cards);
+
+  // Empty state - redirect back to deck page
+  if (allCards.length === 0) {
+    return (
+      <div className="w-full p-6 flex flex-col items-center justify-center h-[80vh] space-y-4">
+        <h2 className="text-2xl font-bold">No cards to study</h2>
+        <p className="text-lg text-muted-foreground">
+          This deck doesn&apos;t have any flashcards yet.
+        </p>
+        <Link
+          href={`/dashboard/decks/${deckId}`}
+          className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2"
+        >
+          Back to Deck
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <StandardStudyMode
+      cards={allCards}
+      deckId={deckId}
+      deckName={deck.name}
+      deckLanguage={deck.language}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Created a new study mode selection interface that presents users with three learning options
- Implemented Standard Study mode (existing flashcard functionality, now accessible via dedicated route)
- Added placeholder pages for Conversational Study and Listening Practice modes (marked as "Coming Soon")
- Improved UX with animated mode cards, clear descriptions, and smooth navigation between modes
- Maintained existing standard study functionality while preparing architecture for future learning modes

## Test plan

- [ ] Navigate to a deck with flashcards and click "Study"
- [ ] Verify the study mode selection page displays three options with icons and descriptions
- [ ] Click "Standard Study" and verify the existing flashcard interface works correctly
- [ ] Test keyboard navigation (arrows for previous/next, space for flip) in standard study mode
- [ ] Click back and select "Conversational Study" - verify the "Coming Soon" page displays
- [ ] Click back and select "Listening Practice" - verify the "Coming Soon" page displays
- [ ] Verify all navigation buttons work correctly (back to modes, back to deck)
- [ ] Test with an empty deck to ensure proper empty state handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)