### PR TITLE
Harden installs: min-release-age=7

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+# Only install package versions published at least 7 days ago.
+# Mitigates fresh malicious publishes (e.g. Shai-Hulud waves). Requires npm >= 11.5.
+# Override per-command with `--min-release-age=0` when you genuinely need a brand-new release.
+min-release-age=7


### PR DESCRIPTION
## Summary
- Add `.npmrc` with `min-release-age=7` so npm refuses to install package versions newer than 7 days.
- Defense against fresh supply-chain compromises (Shai-Hulud-style worms typically get caught and unpublished within a day or two).
- Vercel reads repo-root `.npmrc` automatically, so the deploy build picks it up too.
- Requires npm >= 11.5; on older clients the setting is silently ignored (still safe).

## Test plan
- [ ] Vercel preview build still succeeds on this branch
- [ ] Confirm Vercel build environment uses npm >= 11.5 (otherwise the setting is a no-op for deploys)
- [ ] Override path documented for genuine fresh-release needs: `npm install <pkg> --min-release-age=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)